### PR TITLE
Fix nested/qualified modules

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,29 @@
+# editorconfig.org
+
+root = true
+
+[*]
+charset = utf-8
+indent_size = 2
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.gitignore]
+end_of_line = unset
+
+[*.{bat,cmd,ps1}]
+end_of_line = crlf
+
+[*.{html,htm,xhtml,xml}]
+indent_size = 2
+
+[*.{css,scss,sass}]
+indent_size = 2
+
+[*.{json}]
+indent_style = tab
+
+[*.{yml,yaml}]
+indent_style = space
+indent_size = 2

--- a/benchmarks/runtimemetrics/dub.json
+++ b/benchmarks/runtimemetrics/dub.json
@@ -35,7 +35,6 @@
 	"dependencies": {
 		"openmethods": {
 			"path": "../../",
-			"version": ">=0.0.0"
 		}
 	},
 	"description": "test against large code base",

--- a/examples/acceptnovisitors/dub.json
+++ b/examples/acceptnovisitors/dub.json
@@ -36,7 +36,6 @@
 	"dependencies": {
 		"openmethods": {
 			"path": "../../",
-			"version": ">=0.0.0"
 		}
 	},
 	"description": "replace awful visitor with neat open method",

--- a/examples/adventure/dub.json
+++ b/examples/adventure/dub.json
@@ -36,7 +36,6 @@
 	"dependencies": {
 		"openmethods": {
 			"path": "../../",
-			"version": ">=0.0.0"
 		}
 	},
 	"description": "example of a method with three virtual arguments",

--- a/examples/matrix/dub.json
+++ b/examples/matrix/dub.json
@@ -36,7 +36,6 @@
 	"dependencies": {
 		"openmethods": {
 			"path": "../../",
-			"version": ">=0.0.0"
 		}
 	},
 	"description": "unary and binary matrix operations with two types of matrices",

--- a/examples/next/dub.json
+++ b/examples/next/dub.json
@@ -36,7 +36,6 @@
 	"dependencies": {
 		"openmethods": {
 			"path": "../../",
-			"version": ">=0.0.0"
 		}
 	},
 	"description": "example of 'next', equivalent to calling super",

--- a/examples/rolex/dub.json
+++ b/examples/rolex/dub.json
@@ -36,7 +36,6 @@
 	"dependencies": {
 		"openmethods": {
 			"path": "../../",
-			"version": ">=0.0.0"
 		}
 	},
 	"description": "Role and Expense example from the yomm11 article on Code Project",

--- a/examples/synopsis/dub.json
+++ b/examples/synopsis/dub.json
@@ -36,7 +36,6 @@
 	"dependencies": {
 		"openmethods": {
 			"path": "../../",
-			"version": ">=0.0.0"
 		}
 	},
 	"description": "synopsis",

--- a/examples/whytheunderscore/dub.json
+++ b/examples/whytheunderscore/dub.json
@@ -36,7 +36,6 @@
 	"dependencies": {
 		"openmethods": {
 			"path": "../../",
-			"version": ">=0.0.0"
 		}
 	},
 	"description": "the reason for the underscore in front of method specializations",

--- a/presentations/dlang-meetup-2017-09-28/index.html
+++ b/presentations/dlang-meetup-2017-09-28/index.html
@@ -1,76 +1,76 @@
 <!doctype html>
 <html>
   <head>
-	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
 
-	<title>reveal.js</title>
+  <title>reveal.js</title>
 
-	<link rel="stylesheet" href="css/reveal.css">
-	<link rel="stylesheet" href="css/theme/black.css">
+  <link rel="stylesheet" href="css/reveal.css">
+  <link rel="stylesheet" href="css/theme/black.css">
 
-	<!-- Theme used for syntax highlighting of code -->
-	<link rel="stylesheet" href="lib/css/zenburn.css">
+  <!-- Theme used for syntax highlighting of code -->
+  <link rel="stylesheet" href="lib/css/zenburn.css">
 
-	<!-- Printing and PDF exports -->
-	<script>
-	  var link = document.createElement( 'link' );
-	  link.rel = 'stylesheet';
-	  link.type = 'text/css';
-	  link.href = window.location.search.match( /print-pdf/gi ) ? 'css/print/pdf.css' : 'css/print/paper.css';
-	  document.getElementsByTagName( 'head' )[0].appendChild( link );
-	</script>
+  <!-- Printing and PDF exports -->
+  <script>
+    var link = document.createElement( 'link' );
+    link.rel = 'stylesheet';
+    link.type = 'text/css';
+    link.href = window.location.search.match( /print-pdf/gi ) ? 'css/print/pdf.css' : 'css/print/paper.css';
+    document.getElementsByTagName( 'head' )[0].appendChild( link );
+  </script>
   </head>
   <body>
-	<div class="reveal">
-	  <div class="slides">
+  <div class="reveal">
+    <div class="slides">
         <section>
           <section data-markdown>
-	        <textarea data-template>
-		      # Open Is Good
-	        </textarea>
+          <textarea data-template>
+          # Open Is Good
+          </textarea>
           </section>
         </section>
         <section>
           <section data-markdown>
-	        <textarea data-template>
-		      ## A Short History of OOP
+          <textarea data-template>
+          ## A Short History of OOP
               * Simula 60, 68
               * Smalltalk 72, 80
               * (~1985 - Common Lisp Object System)
               * 90's: OOP gonna save the world
               * C++, Java, ...
               * 10's: OOP discredited
-	        </textarea>
+          </textarea>
           </section>
         </section>
         <section>
           <section data-markdown class="center">
-	        <textarea data-template>
-		      ## The Expression Problem
+          <textarea data-template>
+          ## The Expression Problem
               behaviors += types
               types += behavior
-	        </textarea>
+          </textarea>
           </section>
           <section data-markdown class="center">
-	        <textarea data-template>
-		      ## behavior += types
+          <textarea data-template>
+          ## behavior += types
               OOP languages are good at this
-	        </textarea>
+          </textarea>
           </section>
           <section data-markdown class="center">
-	        <textarea data-template>
-		      ## types += behaviors
+          <textarea data-template>
+          ## types += behaviors
               functional languages are good at this
-	        </textarea>
+          </textarea>
           </section>
           <section data-markdown class="center">
-	        <textarea data-template>
-		      ## Multi Layered Architectures
+          <textarea data-template>
+          ## Multi Layered Architectures
               - domain objects
               - \+ persistence
               - \+ presentation
-	        </textarea>
+          </textarea>
           </section>
         </section>
         <section>
@@ -144,34 +144,34 @@
         </section>
         <section>
           <section data-markdown>
-	        <textarea data-template>
-		      ## TODO
+          <textarea data-template>
+          ## TODO
               - support templatized methods
               - understand why gdc class-to-class calls are so fast
               - improve speed of interface-to-class calls
               - understand why finding perfect hash with dmd takes so much longer to find than with ldc
               - write a guide / implementation notes
-	        </textarea>
+          </textarea>
           </section>
         </section>
-	  </div>
-	</div>
+    </div>
+  </div>
 
-	<script src="lib/js/head.min.js"></script>
-	<script src="js/reveal.js"></script>
+  <script src="lib/js/head.min.js"></script>
+  <script src="js/reveal.js"></script>
 
-	<script>
-	  // More info about config & dependencies:
-	  // - https://github.com/hakimel/reveal.js#configuration
-	  // - https://github.com/hakimel/reveal.js#dependencies
-	  Reveal.initialize({
-	  dependencies: [
-	  { src: 'plugin/markdown/marked.js' },
-	  { src: 'plugin/markdown/markdown.js' },
-	  { src: 'plugin/notes/notes.js', async: true },
-	  { src: 'plugin/highlight/highlight.js', async: true, callback: function() { hljs.initHighlightingOnLoad(); } }
-	  ]
-	  });
-	</script>
+  <script>
+    // More info about config & dependencies:
+    // - https://github.com/hakimel/reveal.js#configuration
+    // - https://github.com/hakimel/reveal.js#dependencies
+    Reveal.initialize({
+    dependencies: [
+    { src: 'plugin/markdown/marked.js' },
+    { src: 'plugin/markdown/markdown.js' },
+    { src: 'plugin/notes/notes.js', async: true },
+    { src: 'plugin/highlight/highlight.js', async: true, callback: function() { hljs.initHighlightingOnLoad(); } }
+    ]
+    });
+  </script>
   </body>
 </html>

--- a/source/openmethods.d
+++ b/source/openmethods.d
@@ -651,7 +651,7 @@ struct Method(alias module_, string name, int index)
   // ==========================================================================
   // Exceptions
 
-  static ReturnType notImplementedError(QualParams...)
+  static ReturnType notImplementedError(/+ QualParams... +/)
   {
     import std.meta;
     errorHandler(new MethodError(MethodError.NotImplemented, &info));
@@ -660,7 +660,7 @@ struct Method(alias module_, string name, int index)
     }
   }
 
-  static ReturnType ambiguousCallError(QualParams...)
+  static ReturnType ambiguousCallError(/+ QualParams... +/)
   {
     errorHandler(new MethodError(MethodError.AmbiguousCall, &info));
     static if (!is(ReturnType == void)) {

--- a/tests/dub.json
+++ b/tests/dub.json
@@ -10,7 +10,9 @@
     "dflags": ["-mixin=mixins.txt"],
     "importPaths": ["../source", "source"],
     "dependencies": {
-		"openmethods": "*"
+		"openmethods": {
+			"path": "../",
+		}
 	},
     "buildTypes": {
         "x": {

--- a/tests/dub.json
+++ b/tests/dub.json
@@ -7,27 +7,27 @@
 	"license": "Boost Software License 1.0",
 	"name": "tests",
 	"targetType": "library",
-    "dflags": ["-mixin=mixins.txt"],
-    "importPaths": ["../source", "source"],
-    "dependencies": {
+		"dflags": ["-mixin=mixins.txt"],
+		"importPaths": ["../source", "source"],
+		"dependencies": {
 		"openmethods": {
 			"path": "../",
 		}
 	},
-    "buildTypes": {
-        "x": {
-	        "debugVersions": ["explain"],
-	        "buildOptions": ["debugMode", "debugInfo", "unittests"],
-        },
-        "xtc": {
-	        "debugVersions": ["explain", "traceCalls"],
-	        "buildOptions": ["debugMode", "debugInfo", "unittests"],
-        },
-    },
-    "configurations": [
-        {
-            "name": "unittest",
-            "dflags": ["-mixin=mixins.txt"],
-        },
-    ]
+		"buildTypes": {
+				"x": {
+					"debugVersions": ["explain"],
+					"buildOptions": ["debugMode", "debugInfo", "unittests"],
+				},
+				"xtc": {
+					"debugVersions": ["explain", "traceCalls"],
+					"buildOptions": ["debugMode", "debugInfo", "unittests"],
+				},
+		},
+		"configurations": [
+				{
+						"name": "unittest",
+						"dflags": ["-mixin=mixins.txt"],
+				},
+		]
 }

--- a/tests/source/qualified.mod.d
+++ b/tests/source/qualified.mod.d
@@ -1,0 +1,14 @@
+module qualified.mod;
+
+import openmethods;
+mixin(registerMethods);
+
+interface Node {}
+
+void walkNode(virtual!Node);
+
+@method
+void _walkNode(Node node)
+{
+  // Dummy
+}


### PR DESCRIPTION
This fixes an issue that prevented openmethods from being used in nested modules such as:
```
module some.nested.module_;

import openmethods;
mixin(registerMethods);
```

Which caused weird errors like:

mixins.txt(484,34): Error: undefined identifier `module_`
mixins.txt(485,5): Error: alias `some.nested.module_.walkNode` conflicts with alias `some.nested.module_.walkNode` at mixins.txt(484,5)
mixins.txt(485,34): Error: undefined identifier `module_`
